### PR TITLE
[PROPOSAL] Waiting for idle rather than document load

### DIFF
--- a/scripts/webeye.js
+++ b/scripts/webeye.js
@@ -57,7 +57,7 @@ class WebEye {
             height: this.height || 1080
         });
         await page.goto(url, {
-            waitUntil: 'domcontentloaded',
+            waitUntil: 'networkidle2',
             timeout: config.timeout
         });
 


### PR DESCRIPTION
This is a proposal that I'm going to use in my own fork of the bot but that I may discuss with you.

The thing is. The bot is currently configured to wait on `domcontentloaded`. This is fine as it's the fastest possible. However, due to how common web apps are now a day, this is guaranteed to fail on webapps like twitter and others. That's why I think `networkidle2` (which waits until there are few connections open by the chromium engine) may be a better suit for the task at hand as it should handle static sites just as well.

This could also be converted into a settings property instead, and I may do it if that's the direction you wanna follow on this one, but it's a weird setting since the bot admin may not have knowledge the puppeteer waiting settings.

Thanks!